### PR TITLE
Refactors SIGNAL_RECIPIENTS to support multiple groups, adds resizing of images

### DIFF
--- a/index.js
+++ b/index.js
@@ -181,8 +181,8 @@ app.post('/webhook', async (req, res) => {
         // --- Changed section: resize image before sending ---
         // Resize the image to width=300px, height=450px (change as desired)
         const resizedBuffer = await sharp(imageResponse.data)
-          .resize(300, 450, { fit: 'cover' }) // Change dimensions as needed
-          .jpeg({ quality: 80 }) // You can use .png() if you prefer PNG
+          .resize(150, 225, { fit: 'cover' }) // Change dimensions as needed
+          //.jpeg({ quality: 80 }) // You can use .png() if you prefer PNG
           .toBuffer();
 
         // Convert to base64

--- a/index.js
+++ b/index.js
@@ -182,7 +182,7 @@ app.post('/webhook', async (req, res) => {
         // Resize the image to width=300px, height=450px (change as desired)
         const resizedBuffer = await sharp(imageResponse.data)
           .resize(150, 225, { fit: 'cover' }) // Change dimensions as needed
-          //.jpeg({ quality: 80 }) // You can use .png() if you prefer PNG
+          .jpeg({ quality: 100 }) // You can use .png() if you prefer PNG
           .toBuffer();
 
         // Convert to base64

--- a/index.js
+++ b/index.js
@@ -180,9 +180,9 @@ app.post('/webhook', async (req, res) => {
           timeout: 5000 // 5 second timeout
         });
 
-        // Resize the image to width=300px, height=450px (change as desired)
+        // Default image size is width=600px, height=900px (change as desired below)
         const resizedBuffer = await sharp(imageResponse.data)
-          .resize(150, 225, { fit: 'cover' }) // Change dimensions as needed
+          .resize(600, 900, { fit: 'cover' }) // Change dimensions as needed
           .jpeg({ quality: 100 }) // You can use .png() if you prefer PNG
           .toBuffer();
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const axios = require('axios');
+const sharp = require('sharp'); // <-- Added for image resizing
 const app = express();
 app.use(express.json());
 
@@ -176,13 +177,21 @@ app.post('/webhook', async (req, res) => {
           responseType: 'arraybuffer',
           timeout: 5000 // 5 second timeout
         });
-        
+
+        // --- Changed section: resize image before sending ---
+        // Resize the image to width=300px, height=450px (change as desired)
+        const resizedBuffer = await sharp(imageResponse.data)
+          .resize(300, 450, { fit: 'cover' }) // Change dimensions as needed
+          .jpeg({ quality: 80 }) // You can use .png() if you prefer PNG
+          .toBuffer();
+
         // Convert to base64
-        const base64Image = Buffer.from(imageResponse.data).toString('base64');
-        
+        const base64Image = resizedBuffer.toString('base64');
+        // --- End changed section ---
+
         // Add to payload
         signalPayload.base64_attachments = [base64Image];
-        console.log('Successfully added image attachment');
+        console.log('Successfully added resized image attachment');
       } catch (imageError) {
         console.error('Error processing image:', imageError.message);
         // Continue without the image if there's an error

--- a/package.json
+++ b/package.json
@@ -13,5 +13,6 @@
   "dependencies": {
     "axios": "^1.8.4",
     "express": "^4.21.2"
+    "sharp": "^0.32.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
   "dependencies": {
     "axios": "^1.8.4",
     "express": "^4.21.2",
-    "sharp": "^4.21.2"
+    "sharp": "^0.32.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "axios": "^1.8.4",
-    "express": "^4.21.2"
-    "sharp": "^0.32.0"
+    "express": "^4.21.2",
+    "sharp": "^4.21.2"
   }
 }


### PR DESCRIPTION
It looks like the signal-api does not support sending to multiple groups in one API call as far as I can tell.  This refactors how `SIGNAL_RECIPIENTS` functions to make separate API calls for each group configured via the `SIGNAL_RECIPIENTS` environment variable using the same syntax (comma separated) as you had been using, this change also checks for someone using whitespace after the comma and removes it if found.

This also adds the ability to resize the images sent with the API calls if desired, currently hard coded to the default size and quality, it can be manually tweaked if desired, was hoping smaller images might look better when sent in the messages but doesn't make much of a difference due to the image being used being a poster with poster dimensions.

Cheers